### PR TITLE
Update comment in .gitignore for clarity

### DIFF
--- a/smartcontracts/.gitignore
+++ b/smartcontracts/.gitignore
@@ -1,4 +1,4 @@
-# Rust's output directory
+# Rust's output directory to ignore
 target
 
 # Local Soroban settings


### PR DESCRIPTION
Clarify comment for Rust's output directory in .gitignore