### PR TITLE
Define PaymentRecord data types in payment_registry_contract

### DIFF
--- a/smartcontracts/Cargo.lock
+++ b/smartcontracts/Cargo.lock
@@ -710,6 +710,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "payment-registry-contract"
+version = "0.0.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/smartcontracts/contracts/payment_registry_contract/src/types.rs
+++ b/smartcontracts/contracts/payment_registry_contract/src/types.rs
@@ -17,4 +17,24 @@ pub enum Currency {
     VND, // Hỗ trợ thêm cả VNĐ cho Sếp
 }
 
-use soroban_sdk::Symbol;
+use soroban_sdk::{Address, String, Symbol};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PaymentStatus {
+    Pending,
+    Confirmed,
+    Failed,
+    Expired,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PaymentRecord {
+    pub payment_id: String,
+    pub merchant_address: Address,
+    pub amount: i128,
+    pub asset: Address,
+    pub status: PaymentStatus,
+    pub timestamp: u64,
+}


### PR DESCRIPTION
I have defined PaymentRecord and PaymentStatus in types.rs making them Soroban-serializable using #[contracttype]. All tests and compilation checks for the host and WASM target completed successfully! Please let me know if you need any adjustments or if we should move onto the next parts.


closes #1 
closes #2